### PR TITLE
fix: 修复 MD5 多分块消息摘要计算

### DIFF
--- a/src/hash/md5.ts
+++ b/src/hash/md5.ts
@@ -76,7 +76,7 @@ function digest(message: Uint8Array) {
   for (let offset = 0; offset < p.length; ) {
     // 获取分块
     const end = offset + block_size;
-    const current_buffer = p.subarray(offset, end).buffer;
+    const M = new Uint32Array(p.buffer, p.byteOffset + offset, block_size >> 2);
     offset = end;
 
     // 准备状态字
@@ -90,8 +90,6 @@ function digest(message: Uint8Array) {
     let d = D;
 
     // 划分词典
-    const M = new Uint32Array(current_buffer);
-
     /* Round 1 */
     a = FF(a, b, c, d, M[0], 7, K[0]);
     d = FF(d, a, b, c, M[1], 12, K[1]);

--- a/test/hash.test.ts
+++ b/test/hash.test.ts
@@ -31,6 +31,8 @@ it('md5', () => {
   const meow = UTF8('meow, 喵， 🐱')
   expect(md5(_).to(HEX)).toMatchInlineSnapshot('"d41d8cd98f00b204e9800998ecf8427e"')
   expect(md5(meow).to(HEX)).toMatchInlineSnapshot('"49ac572e5f34b3e212e727fbd05df30c"')
+  expect(md5(UTF8('f3166a3a404599d2046ed2aae479b37d54b51d2e85259c9e314042753be7d813')).to(HEX))
+    .toMatchInlineSnapshot('"e1276aa683dc7adb38fd366744d037e5"')
 })
 // * SHA-1
 it('sha1', () => {


### PR DESCRIPTION
## 摘要

- 修复 MD5 多分块消息摘要计算时，分块读取偏移错误的问题。
- 增加 64 字节输入的回归测试，覆盖原来会算出错误摘要的边界场景。

## 原因

原实现使用 `p.subarray(offset, end).buffer` 来准备当前 MD5 分块。

`subarray().buffer` 仍然指向原始底层 `ArrayBuffer`，不会携带当前 subarray 的偏移量。因此当消息填充后需要处理多个 64 字节分块时，后续分块会从底层 buffer 起始位置解析，导致摘要结果错误。

这次改为直接创建带 `byteOffset + offset` 和固定长度的 `Uint32Array` 视图，确保每轮读取的是当前 64 字节分块。

## 验证

- `pnpm test test/hash.test.ts -t md5`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
